### PR TITLE
Remove unsupported terraform concat function

### DIFF
--- a/ec2/main.tf
+++ b/ec2/main.tf
@@ -41,7 +41,7 @@ resource "aws_instance" "ose-node" {
     availability_zone = "${var.aws_availability_zone}"
     key_name = "${var.keypair}"
     tags {
-        Name = "${concat("node", count.index)}"
+        Name = "node${count.index}"
         sshUser = "ec2-user"
         role = "nodes"
     }


### PR DESCRIPTION
I have found following closed terraform issue #6792 that is telling us that concat is not supported for strings anymore. Therefore, I propose to change 

```
Name = "${concat("node", count.index)}"
```

by the simpler expression

```
Name = "node${count.index}"
```

which works fine on my fork...
